### PR TITLE
Fix wrong character removal

### DIFF
--- a/includes/templates/google-news-sitemap.php
+++ b/includes/templates/google-news-sitemap.php
@@ -49,7 +49,7 @@ echo '<?xml version="1.0" encoding="UTF-8"?>';
 		}
 
 		// Remove empty space from the beginning & end of title.
-		$title = trim( $link['title'], '&nbsp;' );
+		$title = trim( str_replace( '&nbsp;', ' ', $link['title'] ) );
 		?>
 		<url>
 			<loc><?php echo esc_url( $link['url'] ); ?></loc>


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
Wrong character removal fixed. 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #29 

### How to test the Change
- Create a new post (posts older than two days will not appear in the sitemap)
- Set the the title `peter is taking google sitemaps for a spin`
- Publish the post
- Go to `your-host/news-sitemap.xml`
- Now you should see the full title in the sitemap. Previously it was `eter is taking sitemaps for a spi`

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Fixed - Wrong character removal from post title


### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @jayedul 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my change.
- [x] All new and existing tests pass.
