### PR TITLE
Return true when pinging Google and there is no WP_Error object returned by wp_remote_get()

### DIFF
--- a/includes/classes/Core.php
+++ b/includes/classes/Core.php
@@ -236,18 +236,17 @@ class Core {
 		$url = site_url( sprintf( '/%s.xml', $this->sitemap_slug ) );
 
 		// Ping Google.
-		$ping = wp_remote_get( sprintf( 'https://www.google.com/ping?sitemap=%s', esc_url_raw( $url ) ), [ 'blocking' => false ] );
+		$ping = wp_remote_get( sprintf( 'https://www.google.com/ping?sitemap=%s', rawurlencode( esc_url_raw( $url ) ) ), [ 'blocking' => false ] );
 
 		if ( ! is_array( $ping ) || is_wp_error( $ping ) ) {
 			return false;
 		}
 
-		// Successful request only if the response code is 200.
-		if ( 200 === wp_remote_retrieve_response_code( $ping ) ) {
-			return true;
-		}
-
-		return false;
+		// Assume a successful ping.
+		// Returning "true" when the "wp_remote_get()" method doesn't return a "WP_Error" object for non-blocking requests.
+		// When a "WP_Error" object is not returned, there is no way to determine if the request was successful or not.
+		// Provided that the URL is correct and reachable, it should be OK to return "true" in that case.
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
### Description of the Change
In this PR I'm modifying the `Core::ping_google()` method which always returns `false` to return `true` instead when the `wp_remote_get() ` method doesn't return a `WP_Error` object for non-blocking requests. When a `WP_Error` object is not returned, there is no way to determine if the request was successful or not.

Provided that the URL is correct and reachable, it should be OK to return `true` in that case.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/simple-google-news-sitemap/issues/22

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Changed - Modified the way "Core::ping_google()" responds when "wp_remote_get()" method doesn't return a "WP_Error" object for non-blocking requests.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
