### PR TITLE
Bump WordPress "tested up to" version 6.6

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Simple Google News Sitemap ===
 Contributors:      10up, jeffpaul, dkotter, akshitsethi, ritteshpatel, brentvr
 Tags:              sitemap, Google News
-Tested up to:      6.5
+Tested up to:      6.6
 Stable tag:        1.1.0
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/simple-google-news-sitemap.php
+++ b/simple-google-news-sitemap.php
@@ -11,7 +11,7 @@
  * Plugin URI:        https://github.com/10up/simple-google-news-sitemap
  * Description:       A simple Google News sitemap is generated on-the-fly for articles that were published in the last two days.
  * Version:           1.1.0
- * Requires at least: 6.3
+ * Requires at least: 6.4
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com


### PR DESCRIPTION
### Description of the Change

This PR bumps the WP tested-up-to version to 6.6 and bumps the WP min to 6.4.

Closes #41 

### How to test the Change

Testing already done in #41 

### Changelog Entry

> Changed - Bump WordPress "tested up to" version 6.6.
> Changed - Bump WordPress minimum from 6.3 to 6.4.


### Credits

Props @mohitwp, @dkotter

### Checklist:

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests pass.
