### PR TITLE
bump supported WP version to 6.8 and minimum version to 6.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Simple Google News Sitemap](https://github.com/10up/simple-google-news-sitemap/blob/develop/.wordpress-org/banner-1544x500.png)
 
-[![Support Level](https://img.shields.io/badge/support-beta-blueviolet.svg)](#support-level) [![Release Version](https://img.shields.io/github/release/10up/simple-google-news-sitemap.svg)](https://github.com/10up/simple-google-news-sitemap/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v6.4%20tested-success.svg) [![License](https://img.shields.io/github/license/10up/simple-google-news-sitemap.svg)](https://github.com/10up/simple-google-news-sitemap/blob/develop/LICENSE.md) [![Dependency Review](https://github.com/10up/simple-google-news-sitemap/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/10up/simple-google-news-sitemap/actions/workflows/dependency-review.yml)
+[![Support Level](https://img.shields.io/badge/support-beta-blueviolet.svg)](#support-level) [![Release Version](https://img.shields.io/github/release/10up/simple-google-news-sitemap.svg)](https://github.com/10up/simple-google-news-sitemap/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v6.8%20tested-success.svg) [![License](https://img.shields.io/github/license/10up/simple-google-news-sitemap.svg)](https://github.com/10up/simple-google-news-sitemap/blob/develop/LICENSE.md) [![Dependency Review](https://github.com/10up/simple-google-news-sitemap/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/10up/simple-google-news-sitemap/actions/workflows/dependency-review.yml)
 [![Linting](https://github.com/10up/simple-google-news-sitemap/actions/workflows/lint.yml/badge.svg)](https://github.com/10up/simple-google-news-sitemap/actions/workflows/lint.yml) [![Test](https://github.com/10up/simple-google-news-sitemap/actions/workflows/test.yml/badge.svg)](https://github.com/10up/simple-google-news-sitemap/actions/workflows/test.yml) [![CodeQL scanning](https://github.com/10up/simple-google-news-sitemap/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/10up/simple-google-news-sitemap/actions/workflows/codeql-analysis.yml)
 
 > A simple Google News sitemap is generated on-the-fly for articles that were published in the last two days. Output is saved in cache or as a transient for fast reading and displaying on the front end.
@@ -24,7 +24,7 @@
 ## Requirements
 
 - PHP 7.4+
-- [WordPress](http://wordpress.org/) 6.5+
+- [WordPress](http://wordpress.org/) 6.6+
 
 ## Usage
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Simple Google News Sitemap ===
 Contributors:      10up, jeffpaul, dkotter, akshitsethi, ritteshpatel, brentvr
 Tags:              sitemap, Google News
-Tested up to:      6.7
+Tested up to:      6.8
 Stable tag:        1.1.1
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/simple-google-news-sitemap.php
+++ b/simple-google-news-sitemap.php
@@ -11,7 +11,7 @@
  * Plugin URI:        https://github.com/10up/simple-google-news-sitemap
  * Description:       A simple Google News sitemap is generated on-the-fly for articles that were published in the last two days.
  * Version:           1.1.1
- * Requires at least: 6.5
+ * Requires at least: 6.6
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com


### PR DESCRIPTION
### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

- Increase "tested up to" WP version to 6.8
- Increases minimum supported WP version to 6.6, by request of @jeffpaul 

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #53

This plugin was tested against WP 6.8 in the following ways:
1. 🛑  attempted to run PHPUnit tests on Local WP — not compatible with Local WP, resulting in #54 
2. ✅ installed plugin on a 6.8 site under PHP 8.1 — plugin activated without error
3. ✅ On a site with no posts, visited `/news-sitemap.xml` — empty sitemap
4. ✅ : On a site with 100 posts generated by `wp post generate`, visited `/news-sitemap.xml` — 100 `<url>` are present in the `<urlset>`
5. 🛑 On the same site, with an additional 100 posts generated by `wp post generate`, visited `/news-sitemap.xml` — only the first 100 posts published are visible as `<url>` are present in the `<urlset>`. The more-recentlly-published posts are absent, even after `wp cache flush`.

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

- check that the plugin installs and loads on WP 6.8
- view `README.md` to check that the WordPress "Tested up to" badge loads and that the minimum WordPress version is updated too. https://github.com/10up/simple-google-news-sitemap/tree/feat/wp-6.8

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - New feature
> Changed - Existing functionality
> Deprecated - Soon-to-be removed feature
> Removed - Feature
> Fixed - Bug fix
> Security - Vulnerability
> Developer - Non-functional update

### Credits
<!-- Please list any and all contributors on this PR so that they can be added to this projects CREDITS.md file. -->
Props @username, @username2, ...

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
