### PR TITLE
Add news sitemap link to plugin list

### DIFF
--- a/includes/classes/Core.php
+++ b/includes/classes/Core.php
@@ -36,6 +36,8 @@ class Core {
 		add_action( 'transition_post_status', [ $this, 'purge_sitemap_data_on_status_change' ], 1000, 3 );
 		add_action( 'publish_post', [ $this, 'ping_google' ], 2000 );
 		add_action( 'delete_post', [ $this, 'purge_sitemap_data_on_delete' ], 1000, 2 );
+
+		add_filter( 'plugin_action_links_simple-google-news-sitemap/simple-google-news-sitemap.php', [ __CLASS__, 'sitemap_link' ], 10, 1 );
 	}
 
 	/**
@@ -279,6 +281,21 @@ class Core {
 
 		// For rest, we do nothing.
 		return false;
+	}
+
+	/**
+	 * Add the Simple Google News Sitemap sitemap link to its plugin list
+	 *
+	 * @param string[] $actions
+	 * @return string[]
+	 */
+	public static function sitemap_link( $actions ) {
+		$actions[] = sprintf(
+			'<a href="%1$s">news-sitemap.xml</a>',
+			home_url( 'news-sitemap.xml' )
+		);
+
+		return $actions;
 	}
 
 }

--- a/includes/classes/Core.php
+++ b/includes/classes/Core.php
@@ -286,7 +286,7 @@ class Core {
 	/**
 	 * Add the Simple Google News Sitemap sitemap link to its plugin list
 	 *
-	 * @param string[] $actions
+	 * @param string[] $actions Plugin actions.
 	 * @return string[]
 	 */
 	public static function sitemap_link( $actions ) {

--- a/includes/classes/Core.php
+++ b/includes/classes/Core.php
@@ -292,7 +292,7 @@ class Core {
 	public static function sitemap_link( $actions ) {
 		$actions[] = sprintf(
 			'<a href="%1$s">news-sitemap.xml</a>',
-			home_url( 'news-sitemap.xml' )
+			esc_url( home_url( 'news-sitemap.xml' ) )
 		);
 
 		return $actions;


### PR DESCRIPTION
<!--
Filling out this template is required.  Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
<!--
We must be able to understand the design of your change from this description.  The maintainer reviewing this PR may not have worked with this code recently, so please provide as much detail as possible.

Where possible, please also include:
- verification steps to ensure your change has the desired effects and has not introduced any regressions
- any benefits that will be realized
- any alternative implementations or possible drawbacks that you considered
- screenshots or screencasts
-->

Adds a link to the News Sitemap to this plugin's plugin actions, to make it easier to find.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes https://github.com/10up/simple-google-news-sitemap/issues/56

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->

1. Open Dashboard > Plugins
2. Find the Simple Google News Sitemap entry
3. Check that there's an action for `news-sitemap.xml`
4. Click the link. It should load the sitemap.

![Screenshot 2025-06-20 at 17 50 02](https://github.com/user-attachments/assets/2b65823a-5618-4ce2-816a-714418e2c40a)


### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->
> Added - Link to `news-sitemap.xml` from Plugin list entry.

### Credits


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [ ] All new and existing tests pass.
