### PR TITLE
Tested Compatibility against WP Core 7 RC-3 and RC-4

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Simple Google News Sitemap](https://github.com/10up/simple-google-news-sitemap/blob/develop/.wordpress-org/banner-1544x500.png)
 
-[![Support Level](https://img.shields.io/badge/support-beta-blueviolet.svg)](#support-level) [![Release Version](https://img.shields.io/github/release/10up/simple-google-news-sitemap.svg)](https://github.com/10up/simple-google-news-sitemap/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v6.8%20tested-success.svg) [![License](https://img.shields.io/github/license/10up/simple-google-news-sitemap.svg)](https://github.com/10up/simple-google-news-sitemap/blob/develop/LICENSE.md) [![Dependency Review](https://github.com/10up/simple-google-news-sitemap/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/10up/simple-google-news-sitemap/actions/workflows/dependency-review.yml) [![WordPress Playground Demo](https://img.shields.io/badge/Playground_Demo-8A2BE2?logo=wordpress&logoColor=FFFFFF&labelColor=3858E9&color=3858E9)](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/10up/simple-google-news-sitemap/develop/.github/blueprints/blueprint.json)
+[![Support Level](https://img.shields.io/badge/support-beta-blueviolet.svg)](#support-level) [![Release Version](https://img.shields.io/github/release/10up/simple-google-news-sitemap.svg)](https://github.com/10up/simple-google-news-sitemap/releases/latest) ![WordPress tested up to version](https://img.shields.io/badge/WordPress-v7.0%20tested-success.svg) [![License](https://img.shields.io/github/license/10up/simple-google-news-sitemap.svg)](https://github.com/10up/simple-google-news-sitemap/blob/develop/LICENSE.md) [![Dependency Review](https://github.com/10up/simple-google-news-sitemap/actions/workflows/dependency-review.yml/badge.svg)](https://github.com/10up/simple-google-news-sitemap/actions/workflows/dependency-review.yml) [![WordPress Playground Demo](https://img.shields.io/badge/Playground_Demo-8A2BE2?logo=wordpress&logoColor=FFFFFF&labelColor=3858E9&color=3858E9)](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/10up/simple-google-news-sitemap/develop/.github/blueprints/blueprint.json)
 [![Linting](https://github.com/10up/simple-google-news-sitemap/actions/workflows/lint.yml/badge.svg)](https://github.com/10up/simple-google-news-sitemap/actions/workflows/lint.yml) [![Test](https://github.com/10up/simple-google-news-sitemap/actions/workflows/test.yml/badge.svg)](https://github.com/10up/simple-google-news-sitemap/actions/workflows/test.yml) [![CodeQL scanning](https://github.com/10up/simple-google-news-sitemap/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/10up/simple-google-news-sitemap/actions/workflows/codeql-analysis.yml)
 
 > A simple Google News sitemap is generated on-the-fly for articles that were published in the last two days. Output is saved in cache or as a transient for fast reading and displaying on the front end.
@@ -24,7 +24,7 @@
 ## Requirements
 
 - PHP 7.4+
-- [WordPress](http://wordpress.org/) 6.6+
+- [WordPress](http://wordpress.org/) 6.8+
 
 ## Usage
 

--- a/readme.txt
+++ b/readme.txt
@@ -29,7 +29,7 @@ A simple Google News sitemap is generated on-the-fly for articles that were publ
 == Requirements ==
 
 - PHP 7.4+
-- [WordPress](http://wordpress.org/) 6.5+
+- [WordPress](http://wordpress.org/) 6.8+
 
 == Usage ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Simple Google News Sitemap ===
 Contributors:      10up, jeffpaul, dkotter, akshitsethi, ritteshpatel, brentvr
 Tags:              sitemap, Google News
-Tested up to:      6.8
+Tested up to:      7.0
 Stable tag:        1.1.1
 License:           GPLv2 or later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/simple-google-news-sitemap.php
+++ b/simple-google-news-sitemap.php
@@ -11,7 +11,7 @@
  * Plugin URI:        https://github.com/10up/simple-google-news-sitemap
  * Description:       A simple Google News sitemap is generated on-the-fly for articles that were published in the last two days.
  * Version:           1.1.1
- * Requires at least: 6.6
+ * Requires at least: 6.8
  * Requires PHP:      7.4
  * Author:            10up
  * Author URI:        https://10up.com


### PR DESCRIPTION
### Description of the Change
Tested the compatibility against WordPress 7.0 RC-3 and RC-4
Closes #59 

### How to test the Change
=> Follow one of the steps outlined here: https://wordpress.org/news/2026/05/wordpress-7-0-release-candidate-4/ to test the compatibility of the plugin against WP Core 7.0 RCs.
=> Once done visit your blog's sitemap page /news-sitemap.xml
=> The sitemap should get generated without any issues

### Changelog Entry
> Developer - Compatibility Check Against WP Core 7 Release

### Credits
Props @zamanq 

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added [Critical Flows, Test Cases, and/or End-to-End Tests](https://10up.github.io/Open-Source-Best-Practices/testing/) to cover my change.
- [x] All new and existing tests pass.
